### PR TITLE
Task 7 (Lambda Authorizer + Cognito Authorization)

### DIFF
--- a/src/authorization-service/handlers/basic-authorizer.ts
+++ b/src/authorization-service/handlers/basic-authorizer.ts
@@ -1,0 +1,24 @@
+import { ForbiddenError, verifyAuthorizationHeader } from '@nodejsaws/shared';
+import {
+  APIGatewayAuthorizerResult,
+  APIGatewayTokenAuthorizerEvent,
+  APIGatewayTokenAuthorizerHandler,
+} from 'aws-lambda';
+import { policyService } from '../policy.service';
+
+export const handler: APIGatewayTokenAuthorizerHandler = async (
+  event: APIGatewayTokenAuthorizerEvent
+): Promise<APIGatewayAuthorizerResult> => {
+  console.log(event);
+
+  try {
+    await verifyAuthorizationHeader(event.authorizationToken);
+    return policyService.generateAllow(event);
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      return policyService.generateDeny(event);
+    }
+
+    return error.message;
+  }
+};

--- a/src/authorization-service/policy.service.ts
+++ b/src/authorization-service/policy.service.ts
@@ -1,0 +1,37 @@
+import { APIGatewayTokenAuthorizerEvent } from 'aws-lambda';
+
+export enum PolicyStatementEffect {
+  Allow = 'Allow',
+  Deny = 'Deny',
+}
+
+export class PolicyService {
+  private generatePolicy(
+    event: APIGatewayTokenAuthorizerEvent,
+    effect: PolicyStatementEffect
+  ) {
+    return {
+      principalId: event.authorizationToken,
+      policyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Action: 'execute-api:Invoke',
+            Effect: effect,
+            Resource: event.methodArn,
+          },
+        ],
+      },
+    };
+  }
+
+  public generateAllow(event: APIGatewayTokenAuthorizerEvent) {
+    return this.generatePolicy(event, PolicyStatementEffect.Allow);
+  }
+
+  public generateDeny(event: APIGatewayTokenAuthorizerEvent) {
+    return this.generatePolicy(event, PolicyStatementEffect.Deny);
+  }
+}
+
+export const policyService = new PolicyService();

--- a/src/authorization-service/serverless.yml
+++ b/src/authorization-service/serverless.yml
@@ -1,0 +1,37 @@
+service: authorization-service
+plugins:
+  - serverless-offline
+  - serverless-webpack
+  - serverless-dotenv-plugin
+package:
+  individually: false
+  excludeDevDependencies: false
+provider:
+  name: aws
+  region: eu-west-1
+  stage: ${self:custom.stage}
+  runtime: nodejs12.x
+  apiGateway:
+    minimumCompressionSize: 1024
+  environment:
+    AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
+functions:
+  basicAuthorizer:
+    handler: handlers/basic-authorizer.handler
+resources:
+  Outputs:
+    basicAuthorizerArn:
+      Value:
+        Fn::GetAtt:
+          - BasicAuthorizerLambdaFunction
+          - Arn
+
+custom:
+  stage: ${opt:stage,'dev'}
+  webpack:
+    webpackConfig: ./webpack.config.js
+    includeModules:
+      packagePath: ../../package.json
+  dotenv:
+    path: ../../.env
+    logging: false

--- a/src/authorization-service/webpack.config.js
+++ b/src/authorization-service/webpack.config.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const { merge } = require('webpack-merge');
+const baseConfig = require('../../webpack.config.base');
+
+module.exports = merge(baseConfig, {
+  context: path.resolve(__dirname),
+});

--- a/src/import-service/serverless.yml
+++ b/src/import-service/serverless.yml
@@ -41,6 +41,12 @@ functions:
             parameters:
               querystrings:
                 name: true
+          authorizer:
+            type: token
+            name: basicAuthorizer
+            arn: ${cf:authorization-service-${self:provider.stage}.basicAuthorizerArn}
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
   importFileParser:
     handler: handlers/import-file-parser.handler
     events:
@@ -57,6 +63,15 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: catalogItemsQueue
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId:
+          Ref: ApiGatewayRestApi
   Outputs:
     SQSQueueArn:
       Value:

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,7 @@
+export class DomainError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,5 @@ export * from './http-status-code.enum';
 export * from './product.interface';
 export * from './queue-service';
 export * from './notification-service';
+export * from './errors';
+export * from './jwt';

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,65 @@
+import { DomainError } from './errors';
+
+export interface TokenPayload {
+  username?: string;
+  password?: string;
+}
+
+export class UnauthorizedError extends DomainError {
+  constructor() {
+    super('Unauthorized');
+  }
+}
+
+export class ForbiddenError extends DomainError {
+  constructor() {
+    super('Forbidden');
+  }
+}
+
+export class InvalidTokenError extends DomainError {
+  constructor() {
+    super('Invalid token');
+  }
+}
+
+export function decodeToken(token: string): TokenPayload {
+  try {
+    const [username, password] = Buffer.from(token, 'base64')
+      .toString('utf-8')
+      .split(':');
+
+    return { username, password };
+  } catch {
+    throw new InvalidTokenError();
+  }
+}
+
+export async function verifyToken(token: string): Promise<TokenPayload> {
+  const { username, password } = decodeToken(token);
+
+  if (username && password) {
+    const userPassword = process.env[username.toLowerCase()];
+
+    if (userPassword && password === userPassword) {
+      return { username, password };
+    }
+  }
+
+  throw new ForbiddenError();
+}
+
+export function isToken(token: string): boolean {
+  return /Basic\s[A-Za-z0-9-_=]*$/.test(token);
+}
+
+export async function verifyAuthorizationHeader(
+  token: string
+): Promise<TokenPayload> {
+  if (isToken(token)) {
+    token = token.replace(/Basic\s/, '');
+    return await verifyToken(token);
+  }
+
+  throw new UnauthorizedError();
+}


### PR DESCRIPTION
[https://d3g8l2l9ox55vo.cloudfront.net/admin/products](https://d3g8l2l9ox55vo.cloudfront.net/admin/products)
[https://usprqf7o6k.execute-api.eu-west-1.amazonaws.com/dev/import?name=products.csv](https://usprqf7o6k.execute-api.eu-west-1.amazonaws.com/dev/import?name=products.csv)

**Evaluation criteria (each mark includes previous mark criteria)**

1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file ✅
3 - import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided. ✅
5 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token') ✅

Additional (optional) tasks
+1 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file ✅

`authorization_token: c3RhbnNodW1za3k6VEVTVF9QQVNTV09SRA==`